### PR TITLE
remove blue underline from 2021 thing at bottom of page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -21,3 +21,7 @@
 max-width: 1000px;
 max-height: 1000px;
 }
+
+A {
+    text-decoration: none;
+}


### PR DESCRIPTION
I'm only pushing the "remove blue underline" part of my code this time and not any of the light-dark mode stuff. So it shouldn't have any conflicts this time. 